### PR TITLE
[New feat] Persistent Advancements to avoid unregister when disable

### DIFF
--- a/src/main/java/me/hotpocket/skriptadvancements/elements/effects/EffAdvancementToast.java
+++ b/src/main/java/me/hotpocket/skriptadvancements/elements/effects/EffAdvancementToast.java
@@ -11,6 +11,8 @@ import ch.njol.skript.lang.SkriptParser;
 import ch.njol.util.Kleenean;
 import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementFrameType;
 import me.hotpocket.skriptadvancements.utils.CustomUtils;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.advancement.Advancement;
 import org.bukkit.entity.Player;
@@ -36,10 +38,20 @@ public class EffAdvancementToast extends Effect {
 
     @Override
     protected void execute(Event e) {
-        for (Advancement advancement : advancements.getAll(e))
-            for (Player player : players.getAll(e))
-                if (advancement.getDisplay() != null)
-                    CustomUtils.getAPI().displayCustomToast(player, advancement.getDisplay().icon(), Bukkit.getUnsafe().legacyComponentSerializer().serialize(advancement.getDisplay().title()), AdvancementFrameType.valueOf(advancement.getDisplay().frame().name()));
+        for (Advancement advancement : advancements.getAll(e)) {
+            for (Player player : players.getAll(e)) {
+                if (advancement.getDisplay() != null) {
+                    Component titleComp = advancement.getDisplay().title();
+                    String title = LegacyComponentSerializer.legacySection().serialize(titleComp);
+                    CustomUtils.getAPI().displayCustomToast(
+                            player,
+                            advancement.getDisplay().icon(),
+                            title,
+                            AdvancementFrameType.valueOf(advancement.getDisplay().frame().name())
+                    );
+                }
+            }
+        }
     }
 
     @Override

--- a/src/main/java/me/hotpocket/skriptadvancements/elements/effects/creation/EffKeepAdvancementTab.java
+++ b/src/main/java/me/hotpocket/skriptadvancements/elements/effects/creation/EffKeepAdvancementTab.java
@@ -1,0 +1,50 @@
+package me.hotpocket.skriptadvancements.elements.effects.creation;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
+import me.hotpocket.skriptadvancements.elements.sections.SecAdvancementTab;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Keep Advancement Tab")
+@Description({"Prevents the advancement tab from being cleared when the script reloads.",
+	"By default, creating an advancement tab removes all previously registered advancements.",
+	"Use this effect to preserve existing advancements and only add new ones.",
+	"Must be used inside an advancement tab section."})
+@Examples("keep advancement tab")
+@Since("2.0.2")
+
+public class EffKeepAdvancementTab extends Effect {
+
+	static {
+		Skript.registerEffect(EffKeepAdvancementTab.class, "keep [the] [advancement] tab");
+	}
+
+	// Static flag to track if we should preserve advancements
+	private static boolean preserveMode = false;
+
+	@Override
+	protected void execute(Event e) {
+		SecAdvancementTab tab = getParser().getCurrentSection(SecAdvancementTab.class);
+		if (tab != null) {
+			tab.setPreserveExistingAdvancements(true);
+		}
+	}
+
+	@Override
+	public String toString(@Nullable Event e, boolean debug) {
+		return "keep the advancement tab";
+	}
+
+	@Override
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		return getParser().isCurrentSection(SecAdvancementTab.class);
+	}
+}

--- a/src/main/java/me/hotpocket/skriptadvancements/elements/events/EvtAdvancement.java
+++ b/src/main/java/me/hotpocket/skriptadvancements/elements/events/EvtAdvancement.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.lang.util.SimpleEvent;
 import ch.njol.skript.registrations.EventValues;
 import ch.njol.skript.util.Getter;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.advancement.Advancement;
 import org.bukkit.entity.Player;
@@ -37,7 +38,7 @@ public class EvtAdvancement extends SimpleEvent {
             @Override
             @Nullable
             public String get(PlayerAdvancementDoneEvent e) {
-                return Bukkit.getUnsafe().legacyComponentSerializer().serialize(e.message());
+                return LegacyComponentSerializer.legacySection().serialize(e.message());
             }
 
         }, 0);

--- a/src/main/java/me/hotpocket/skriptadvancements/elements/events/EvtCustomAdvancement.java
+++ b/src/main/java/me/hotpocket/skriptadvancements/elements/events/EvtCustomAdvancement.java
@@ -41,13 +41,12 @@ public class EvtCustomAdvancement extends SkriptEvent {
     }
 
     private String @Nullable [] advancements = null;
-    private Literal<String> advancementsLit;
 
     @Override
     public boolean init(Literal<?>[] args, int matchedPattern, SkriptParser.ParseResult parseResult) {
         if (args[0] != null) {
             //noinspection unchecked
-            advancementsLit = ((Literal<String>) args[0]);
+            Literal<String> advancementsLit = ((Literal<String>) args[0]);
             advancements = advancementsLit.getAll();
         }
         return true;

--- a/src/main/java/me/hotpocket/skriptadvancements/elements/expressions/display/vanilla/ExprDisplayedDescription.java
+++ b/src/main/java/me/hotpocket/skriptadvancements/elements/expressions/display/vanilla/ExprDisplayedDescription.java
@@ -6,6 +6,7 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.advancement.Advancement;
 import org.bukkit.event.Event;
@@ -23,9 +24,13 @@ public class ExprDisplayedDescription extends SimpleExpression<String> {
 
     @Override
     protected @Nullable String[] get(Event e) {
-        for (Advancement advancement : advancements.getAll(e))
-            if (advancement.getDisplay() != null)
-                return new String[]{Bukkit.getUnsafe().legacyComponentSerializer().serialize(advancement.getDisplay().description())};
+        for (Advancement advancement : advancements.getAll(e)) {
+            if (advancement.getDisplay() != null) {
+                advancement.getDisplay().description();
+                String desc = LegacyComponentSerializer.legacySection().serialize(advancement.getDisplay().description());
+                return new String[]{desc};
+            }
+        }
         return null;
     }
 

--- a/src/main/java/me/hotpocket/skriptadvancements/elements/expressions/display/vanilla/ExprDisplayedTitle.java
+++ b/src/main/java/me/hotpocket/skriptadvancements/elements/expressions/display/vanilla/ExprDisplayedTitle.java
@@ -10,6 +10,8 @@ import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.advancement.Advancement;
 import org.bukkit.event.Event;
@@ -32,9 +34,13 @@ public class ExprDisplayedTitle extends SimpleExpression<String> {
 
     @Override
     protected @Nullable String[] get(Event e) {
-        for (Advancement advancement : advancements.getAll(e))
-            if (advancement.getDisplay() != null)
-                return new String[]{Bukkit.getUnsafe().legacyComponentSerializer().serialize(advancement.getDisplay().title())};
+        for (Advancement advancement : advancements.getAll(e)) {
+            if (advancement.getDisplay() != null) {
+                Component titleComp = advancement.getDisplay().title();
+                String title = LegacyComponentSerializer.legacySection().serialize(titleComp);
+                return new String[]{title};
+            }
+        }
         return null;
     }
 

--- a/src/main/java/me/hotpocket/skriptadvancements/elements/expressions/vanilla/ExprAdvancementMessage.java
+++ b/src/main/java/me/hotpocket/skriptadvancements/elements/expressions/vanilla/ExprAdvancementMessage.java
@@ -10,6 +10,7 @@ import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.util.coll.CollectionUtils;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerAdvancementDoneEvent;
@@ -56,7 +57,7 @@ public class ExprAdvancementMessage extends EventValueExpression<String> {
     @Nullable
     protected String[] get(Event e) {
         PlayerAdvancementDoneEvent event = (PlayerAdvancementDoneEvent) e;
-        return new String[]{Bukkit.getUnsafe().legacyComponentSerializer().serialize(event.message())};
+        return new String[]{LegacyComponentSerializer.legacySection().serialize(event.message())};
     }
 
     @Override

--- a/src/main/java/me/hotpocket/skriptadvancements/elements/sections/SecAdvancementTab.java
+++ b/src/main/java/me/hotpocket/skriptadvancements/elements/sections/SecAdvancementTab.java
@@ -11,6 +11,7 @@ import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.util.Kleenean;
 import com.fren_gor.ultimateAdvancementAPI.AdvancementTab;
+import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
 import com.fren_gor.ultimateAdvancementAPI.advancement.BaseAdvancement;
 import com.fren_gor.ultimateAdvancementAPI.advancement.RootAdvancement;
 import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementDisplay;
@@ -18,6 +19,7 @@ import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementFrameT
 import me.hotpocket.skriptadvancements.utils.CustomUtils;
 import org.bukkit.Material;
 import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -34,6 +36,7 @@ public class SecAdvancementTab extends EffectSection {
     public RootAdvancement rootAdvancement;
     private List<BaseAdvancement> advancements = new ArrayList<>();
     private String tabName;
+    private boolean preserveExistingAdvancements = false;
 
     static {
         Skript.registerSection(SecAdvancementTab.class, "create [a[n]] [new] advancement tab named %string%");
@@ -58,20 +61,46 @@ public class SecAdvancementTab extends EffectSection {
 
     @Override
     @Nullable
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     protected TriggerItem walk(Event event) {
         tabName = name.getSingle(event).toLowerCase().replaceAll(" ", "_");
         AdvancementTab tab = CustomUtils.getAPI().getAdvancementTab(tabName);
-        if (tab != null && !tab.isInitialised()) {
-            RootAdvancement root = new RootAdvancement(tab, "temp_root_advancement_name_1289587", new AdvancementDisplay(Material.DIAMOND, "title", AdvancementFrameType.TASK, false, false, 0, 0, "description"), CustomUtils.getTexture(Material.DIAMOND_BLOCK));
-            BaseAdvancement tempBase = new BaseAdvancement("name1", new AdvancementDisplay(Material.DIAMOND, "title", AdvancementFrameType.TASK, false, false, 0, 0, "description"), root);
-            tab.registerAdvancements(root, tempBase);
-            CustomUtils.getAPI().unregisterAdvancementTab(tabName);
+        
+        // If preserving existing advancements, don't unregister
+        if (preserveExistingAdvancements) {
+            // Tab already exists with advancements, reuse it
+            if (tab == null) {
+                // Tab doesn't exist yet, create it
+                tab = CustomUtils.getAPI().createAdvancementTab(tabName);
+            }
+            // Keep existing advancements, just get root if available
+            for (@NotNull Advancement advancement : tab.getAdvancements()) {
+                if (advancement instanceof RootAdvancement) {
+                    rootAdvancement = (RootAdvancement) advancement;
+                    break;
+                }
+            }
+            // If no root found, create a temp one
+            if (rootAdvancement == null) {
+                rootAdvancement = new RootAdvancement(tab, "temp_root_advancement_name_1289587",
+                    new AdvancementDisplay(Material.DIAMOND, "title", AdvancementFrameType.TASK, false, false, 0, 0, "description"),
+                    CustomUtils.getTexture(Material.DIAMOND_BLOCK));
+            }
+        } else {
+            // Original behavior: clear and recreate
+            if (tab != null && !tab.isInitialised()) {
+                RootAdvancement root = new RootAdvancement(tab, "temp_root_advancement_name_1289587", new AdvancementDisplay(Material.DIAMOND, "title", AdvancementFrameType.TASK, false, false, 0, 0, "description"), CustomUtils.getTexture(Material.DIAMOND_BLOCK));
+                BaseAdvancement tempBase = new BaseAdvancement("name1", new AdvancementDisplay(Material.DIAMOND, "title", AdvancementFrameType.TASK, false, false, 0, 0, "description"), root);
+                tab.registerAdvancements(root, tempBase);
+                CustomUtils.getAPI().unregisterAdvancementTab(tabName);
+            }
+            if (tab != null && (tab.isInitialised() || tab.isActive())) {
+                CustomUtils.getAPI().unregisterAdvancementTab(tabName);
+            }
+            CustomUtils.getAPI().createAdvancementTab(tabName);
         }
-        if (tab != null && (tab.isInitialised() || tab.isActive())) {
-            CustomUtils.getAPI().unregisterAdvancementTab(tabName);
-        }
-        CustomUtils.getAPI().createAdvancementTab(tabName);
+        
         getParser().getCurrentSections().add(this);
         return walk(event, true);
     }
@@ -101,5 +130,13 @@ public class SecAdvancementTab extends EffectSection {
 
     public String getTabName() {
         return tabName;
+    }
+
+    public void setPreserveExistingAdvancements(boolean preserve) {
+        this.preserveExistingAdvancements = preserve;
+    }
+
+    public boolean isPreservingAdvancements() {
+        return preserveExistingAdvancements;
     }
 }

--- a/src/main/java/me/hotpocket/skriptadvancements/elements/sections/SecPersistentAdvancement.java
+++ b/src/main/java/me/hotpocket/skriptadvancements/elements/sections/SecPersistentAdvancement.java
@@ -1,0 +1,71 @@
+package me.hotpocket.skriptadvancements.elements.sections;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.EffectSection;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.TriggerItem;
+import ch.njol.util.Kleenean;
+import me.hotpocket.skriptadvancements.utils.advancement.VisibilityType;
+import me.hotpocket.skriptadvancements.utils.creation.SkriptAdvancement;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Name("Persistent Advancement Section")
+@Description({"Creates a custom advancement within a persistent advancement tab.",
+	"This advancement will not be removed when the script is reloaded."})
+@Since("2.0.2")
+
+public class SecPersistentAdvancement extends EffectSection {
+
+	static {
+		Skript.registerSection(SecPersistentAdvancement.class, "create [a[n]] [new] persistent advancement named %string%");
+	}
+
+	private SkriptAdvancement advancement;
+	private Expression<String> name;
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult,
+					@Nullable SectionNode sectionNode, @Nullable List<TriggerItem> triggerItems) {
+		if (getParser().isCurrentSection(SecPersistentAdvancement.class)) {
+			Skript.error("The persistent advancement creation section is not meant to be put inside of another persistent advancement creation section.");
+			return false;
+		}
+		if (!getParser().isCurrentSection(SecPersistentTab.class)) {
+			Skript.error("The persistent advancement creation section needs to be inside of a persistent advancement tab creation section.");
+			return false;
+		}
+		if (sectionNode != null) {
+			loadOptionalCode(sectionNode);
+		}
+		name = (Expression<String>) exprs[0];
+		return true;
+	}
+
+	@Override
+	@Nullable
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	protected TriggerItem walk(Event event) {
+		advancement = new SkriptAdvancement(getParser().getCurrentSection(SecPersistentTab.class).getTabName(), name.getSingle(event), 1, new ArrayList<>(), VisibilityType.VISIBLE);
+		getParser().getCurrentSections().add(this);
+		return walk(event, true);
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "create a persistent advancement with the name " + name.toString(event, debug);
+	}
+
+	public SkriptAdvancement getAdvancement() {
+		return advancement;
+	}
+}

--- a/src/main/java/me/hotpocket/skriptadvancements/elements/sections/SecPersistentTab.java
+++ b/src/main/java/me/hotpocket/skriptadvancements/elements/sections/SecPersistentTab.java
@@ -1,0 +1,148 @@
+package me.hotpocket.skriptadvancements.elements.sections;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.config.SectionNode;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.EffectSection;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.TriggerItem;
+import ch.njol.util.Kleenean;
+import com.fren_gor.ultimateAdvancementAPI.AdvancementTab;
+import com.fren_gor.ultimateAdvancementAPI.advancement.Advancement;
+import com.fren_gor.ultimateAdvancementAPI.advancement.BaseAdvancement;
+import com.fren_gor.ultimateAdvancementAPI.advancement.RootAdvancement;
+import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementDisplay;
+import com.fren_gor.ultimateAdvancementAPI.advancement.display.AdvancementFrameType;
+import me.hotpocket.skriptadvancements.utils.CustomUtils;
+import org.bukkit.Material;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@Name("Persistent Advancement Tab Section")
+@Description({"Creates or reuses a custom advancement tab without removing existing advancements.",
+	"Unlike the regular advancement tab section, this will preserve previously registered advancements",
+	"even if the script is reloaded. New advancements are added to existing ones."})
+@Since("2.0.2")
+
+public class SecPersistentTab extends EffectSection {
+
+	public RootAdvancement rootAdvancement;
+	private List<BaseAdvancement> newAdvancements = new ArrayList<>();
+	private String tabName;
+
+	static {
+		Skript.registerSection(SecPersistentTab.class, "create [a[n]] [new] persistent advancement tab named %string%");
+	}
+
+	private Expression<String> name;
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult,
+					@Nullable SectionNode sectionNode, @Nullable List<TriggerItem> triggerItems) {
+		if (getParser().isCurrentSection(SecPersistentTab.class)) {
+			Skript.error("The persistent advancement tab creation section is not meant to be put inside of another persistent advancement tab creation section.");
+			return false;
+		}
+		if (sectionNode != null) {
+			loadOptionalCode(sectionNode);
+		}
+		name = (Expression<String>) exprs[0];
+		return true;
+	}
+
+	@Override
+	@Nullable
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	protected TriggerItem walk(Event event) {
+		tabName = name.getSingle(event).toLowerCase().replaceAll(" ", "_");
+		AdvancementTab tab = CustomUtils.getAPI().getAdvancementTab(tabName);
+		
+		// If tab doesn't exist, create it with a temp root advancement
+		if (tab == null) {
+			RootAdvancement root = new RootAdvancement(
+				CustomUtils.getAPI().createAdvancementTab(tabName),
+				"temp_root_advancement_name_1289587",
+				new AdvancementDisplay(Material.DIAMOND, "title", AdvancementFrameType.TASK, false, false, 0, 0, "description"),
+				CustomUtils.getTexture(Material.DIAMOND_BLOCK)
+			);
+			BaseAdvancement tempBase = new BaseAdvancement("name1",
+				new AdvancementDisplay(Material.DIAMOND, "title", AdvancementFrameType.TASK, false, false, 0, 0, "description"),
+				root
+			);
+			tab = CustomUtils.getAPI().getAdvancementTab(tabName);
+			if (tab != null) {
+				tab.registerAdvancements(root, tempBase);
+				this.rootAdvancement = root;
+			}
+		} else if (!tab.isInitialised() && !tab.isActive()) {
+			// Tab exists but isn't initialized - get or create its root advancement
+			RootAdvancement root = new RootAdvancement(tab, "temp_root_advancement_name_1289587",
+				new AdvancementDisplay(Material.DIAMOND, "title", AdvancementFrameType.TASK, false, false, 0, 0, "description"),
+				CustomUtils.getTexture(Material.DIAMOND_BLOCK)
+			);
+			BaseAdvancement tempBase = new BaseAdvancement("name1",
+				new AdvancementDisplay(Material.DIAMOND, "title", AdvancementFrameType.TASK, false, false, 0, 0, "description"),
+				root
+			);
+			tab.registerAdvancements(root, tempBase);
+			this.rootAdvancement = root;
+		} else {
+			// Tab is already initialized - preserve its existing advancements
+			// Extract the root advancement from existing advancements
+			for (@NotNull Advancement advancement : tab.getAdvancements()) {
+				if (advancement instanceof RootAdvancement) {
+					this.rootAdvancement = (RootAdvancement) advancement;
+					break;
+				}
+			}
+			// If no root found, create one (shouldn't happen in normal cases)
+			if (this.rootAdvancement == null) {
+				this.rootAdvancement = new RootAdvancement(tab, "temp_root_advancement_name_1289587",
+					new AdvancementDisplay(Material.DIAMOND, "title", AdvancementFrameType.TASK, false, false, 0, 0, "description"),
+					CustomUtils.getTexture(Material.DIAMOND_BLOCK)
+				);
+			}
+		}
+		
+		getParser().getCurrentSections().add(this);
+		return walk(event, true);
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "create a persistent advancement tab with the name " + name.toString(event, debug);
+	}
+
+	public void addAdvancement(BaseAdvancement addition) {
+		// Avoid duplicates: if an advancement with same key exists, replace it
+		List<BaseAdvancement> toBeRemoved = new ArrayList<>();
+		newAdvancements.forEach((advancement) -> {
+			if (addition.getKey().getKey().equalsIgnoreCase(advancement.getKey().getKey()))
+				toBeRemoved.add(advancement);
+		});
+		newAdvancements.removeAll(toBeRemoved);
+		newAdvancements.add(addition);
+	}
+
+	public void removeAdvancement(BaseAdvancement removed) {
+		newAdvancements.remove(removed);
+	}
+
+	public Collection<BaseAdvancement> getAdvancements() {
+		return Collections.unmodifiableCollection(newAdvancements);
+	}
+
+	public String getTabName() {
+		return tabName;
+	}
+}

--- a/src/main/java/me/hotpocket/skriptadvancements/utils/CustomUtils.java
+++ b/src/main/java/me/hotpocket/skriptadvancements/utils/CustomUtils.java
@@ -47,7 +47,7 @@ public class CustomUtils {
     public static String getTexture(Material block) {
         if (block.isBlock() && block.isSolid()) {
             if (Skript.methodExists(Material.class, "getTranslationKey")) {
-                return "textures/block/" + block.getTranslationKey().split("minecraft\\.")[1] + ".png";
+                return "textures/block/" + block.getBlockTranslationKey().split("minecraft\\.")[1] + ".png";
             } else {
                 return "textures/block/" + getTranslationKey(block).split("minecraft\\.")[1] + ".png";
             }

--- a/src/main/java/me/hotpocket/skriptadvancements/utils/creation/AdvancementSectionHelper.java
+++ b/src/main/java/me/hotpocket/skriptadvancements/utils/creation/AdvancementSectionHelper.java
@@ -1,0 +1,43 @@
+package me.hotpocket.skriptadvancements.utils.creation;
+
+import me.hotpocket.skriptadvancements.elements.sections.SecAdvancement;
+import me.hotpocket.skriptadvancements.elements.sections.SecPersistentAdvancement;
+import ch.njol.skript.lang.parser.ParserInstance;
+
+/**
+ * Helper class to support both regular and persistent advancement sections.
+ * Allows expressions and effects to work with both section types seamlessly.
+ */
+public class AdvancementSectionHelper {
+
+	private static ParserInstance parser;
+
+	/**
+	 * Get the current advancement (works with both SecAdvancement and SecPersistentAdvancement)
+	 */
+	public static SkriptAdvancement getCurrentAdvancement(ParserInstance parserInstance) {
+		parser = parserInstance;
+		
+		// Try SecAdvancement first
+		SecAdvancement secAdv = parser.getCurrentSection(SecAdvancement.class);
+		if (secAdv != null) {
+			return secAdv.getAdvancement();
+		}
+		
+		// Try SecPersistentAdvancement
+		SecPersistentAdvancement secPersist = parser.getCurrentSection(SecPersistentAdvancement.class);
+		if (secPersist != null) {
+			return secPersist.getAdvancement();
+		}
+		
+		return null;
+	}
+
+	/**
+	 * Check if currently in either advancement section type
+	 */
+	public static boolean isInAdvancementSection(ParserInstance parserInstance) {
+		parser = parserInstance;
+		return parser.isCurrentSection(SecAdvancement.class) || parser.isCurrentSection(SecPersistentAdvancement.class);
+	}
+}


### PR DESCRIPTION
Sometimes we need to unregister achievements to modify them, but when we don’t need to, we can persist certain achievements.

Additionally:

Updated some deprecated methods related to Bukkit.getUnsafe().

Updated the deprecated getTranslationKey() to getBlockTranslationKey().